### PR TITLE
Use static anonymous functions

### DIFF
--- a/server.php
+++ b/server.php
@@ -63,11 +63,11 @@ function bump_stat( string $stat ) {
 $server = new Worker( "Memcached_Text://127.0.0.1:{$options['port']}" );
 $server->count = 4;
 
-$server->onConnect = function ( TcpConnection $conn ) {
+$server->onConnect = static function ( TcpConnection $conn ) {
 	bump_stat( 'total_connections' );
 };
 
-$server->onMessage = function ( TcpConnection $conn, object $data ) {
+$server->onMessage = static function ( TcpConnection $conn, object $data ) {
 #	$storage = new Memcached_Storage( ':memory:' );
 	$storage = new Memcached_Storage( __DIR__ . '/data/marmerine.db' );
 	$storage->enable( 'WAL' );
@@ -251,7 +251,7 @@ $server->onMessage = function ( TcpConnection $conn, object $data ) {
 	}
 };
 
-$server->onClose = function ( TcpConnection $conn ) {
+$server->onClose = static function ( TcpConnection $conn ) {
 };
 
 Worker::runAll();


### PR DESCRIPTION
For performance and memory benefit.

Anonymous functions when declared in the context of a class, the current class is automatically bound to it, making $this available inside of the function's scope. If this automatic binding of the current class is not wanted, then [static anonymous functions](https://www.php.net/manual/en/functions.anonymous.php#functions.anonymous-functions.static) may be used instead.