### PR TITLE
Update version command

### DIFF
--- a/server.php
+++ b/server.php
@@ -73,7 +73,7 @@ $server->onConnect = static function ( TcpConnection $conn ) {
 };
 
 $server->onMessage = static function ( TcpConnection $conn, object $data ) {
-#	$storage = new Memcached_Storage( ':memory:' );
+//	$storage = new Memcached_Storage( ':memory:' );
 	$storage = new Memcached_Storage( __DIR__ . '/data/marmerine.db' );
 	$storage->enable( 'WAL' );
 

--- a/server.php
+++ b/server.php
@@ -250,7 +250,7 @@ $server->onMessage = static function ( TcpConnection $conn, object $data ) {
 			return;
 
 		case 'version':
-			$conn->send( MARMERINE_VERSION );
+			$conn->send( 'VERSION '.MARMERINE_VERSION );
 			return;
 	}
 };


### PR DESCRIPTION
Now show `VERSION 0.0.4`.

Video showing the previous behavior, without VERSION and ERROR.

https://user-images.githubusercontent.com/249085/210775202-da61216b-e6f3-4df1-9097-a196dee8d321.mp4


PD: without VERSION it's working OK with the php extension, but possibly will fail with another client.
It's faster to use `telnet` or `nc` directly, instead of pass any command via pipe | . It's the good thing of use a text protocol.