### PR TITLE
Small performance changes

### DIFF
--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -54,7 +54,7 @@ class Memcached_Storage {
 SQL;
 
 			verbose( "SQLite: $sql" );
-			$create = self::$db->exec( $sql );
+			self::$db->exec( $sql );
 		}
 	}
 

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -115,9 +115,7 @@ SQL;
 		verbose( "SQLite: {$query->getSQL( true )}" );
 		$result = $query->execute();
 
-		return ( $result !== false
-				&& self::$db->changes() === 1
-		);
+		return ( $result !== false && self::$db->changes() === 1 );
 	}
 
 	public function decr( string $key, int $value): mixed {

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -104,8 +104,7 @@ SQL;
 			return false;
 		}
 
-		$results = $this->set( $key, $flags, $exptime, "{$results[0]['value']}$value" );
-		return $results;
+		return $this->set( $key, $flags, $exptime, "{$results[0]['value']}$value" );
 	}
 
 	public function cas( string $key, int $flags, int $exptime, string|int $value, int $cas ): bool {
@@ -154,8 +153,7 @@ SQL;
 	public function flush_all(): bool {
 		$sql = 'DELETE FROM storage';
 		verbose( "SQLite: $sql" );
-		$result = self::$db->exec( $sql );
-		return $result;
+		return self::$db->exec( $sql );
 	}
 
 	public function get( array $keys ): mixed {
@@ -217,8 +215,7 @@ SQL;
 			return false;
 		}
 
-		$results = $this->set( $key, $flags, $exptime, "$value{$results[0]['value']}" );
-		return $results;
+		return $this->set( $key, $flags, $exptime, "$value{$results[0]['value']}" );
 	}
 
 	public function replace( string $key, int $flags, int $exptime, string|int $value ): bool {
@@ -227,8 +224,7 @@ SQL;
 			return false;
 		}
 
-		$result = $this->set( $key, $flags, $exptime, $value );
-		return $result;
+		return $this->set( $key, $flags, $exptime, $value );
 	}
 
 	public function set( string $key, int $flags, int $exptime, string|int $value ): bool {
@@ -255,8 +251,7 @@ SQL;
 		$result = $query->execute();
 
 		if ( $result !== false ) {
-			$row = $result->fetchArray( SQLITE3_ASSOC );
-			return $row['curr_items'];
+			return $result->fetchArray( SQLITE3_ASSOC ) ['curr_items'];
 		}
 
 		return false;
@@ -268,16 +263,11 @@ SQL;
 			return false;
 		}
 
-		$result = $this->set(
+		return $this->set(
 			$key,
 			$current[0]['flags'],
 			$exptime,
 			$current[0]['value']
 		);
-		if ( $result !== false ) {
-			return true;
-		}
-
-		return false;
 	}
 } 

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -62,13 +62,7 @@ SQL;
 		$query = self::$db->prepare( 'DELETE FROM storage WHERE "key" = :key' );
 		$query->bindValue( ':key', $key, SQLITE3_TEXT );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		$result = $query->execute();
-
-		if ( $result === false ) {
-			return false;
-		} else {
-			return true;
-		}
+		return (bool) $query->execute();
 	}
 
 	public function add( string $key, int $flags, int $exptime, string|int $value ): bool {
@@ -89,13 +83,8 @@ SQL;
 		$query->bindValue( ':cas', 1, SQLITE3_INTEGER );
 		$query->bindValue( ':value', $value, SQLITE3_BLOB );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		$result = $query->execute();
+		return (bool) $query->execute();
 
-		if ( $result !== false ) {
-			return true;
-		}
-
-		return false;
 	}
 
 	public function append( string $key, int $flags, int $exptime, string|int $value ): bool {
@@ -236,13 +225,8 @@ SQL;
 		$query->bindValue( ':cas', 1, SQLITE3_INTEGER );
 		$query->bindValue( ':value', $value, SQLITE3_BLOB );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		$result = $query->execute();
+		return (bool) $query->execute();
 
-		if ( $result !== false ) {
-			return true;
-		}
-
-		return false;
 	}
 
 	public function stat_curr_items() {

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -193,8 +193,7 @@ SQL;
 	}
 
 	public function replace( string $key, int $flags, int $exptime, string|int $value ): bool {
-		$current = $this->get( [ $key ] );
-		if ( [] === $current ) {
+		if ( [] === $this->get( [ $key ] ) ) {
 			return false;
 		}
 

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -100,7 +100,7 @@ SQL;
 
 	public function append( string $key, int $flags, int $exptime, string|int $value ): bool {
 		$results = $this->get( [ $key ] );
-		if ( count( $results ) === 0 ) {
+		if ( [] === $results ) {
 			return false;
 		}
 
@@ -142,7 +142,7 @@ SQL;
 
 	public function delete( string $key ): bool {
 		$results = $this->get( [ $key ] );
-		if ( count( $results ) === 0 ) {
+		if ( [] === $results ) {
 			return false;
 		}
 
@@ -185,7 +185,7 @@ SQL;
 
 	public function incr( string $key, int $value): mixed {
 		$results = $this->get( [ $key ] );
-		if ( count( $results ) === 0 ) {
+		if ( [] === $results ) {
 			return false;
 		}
 
@@ -211,7 +211,7 @@ SQL;
 
 	public function prepend( string $key, int $flags, int $exptime, string|int $value ): bool {
 		$results = $this->get( [ $key ] );
-		if ( count( $results ) === 0 ) {
+		if ( [] === $results ) {
 			return false;
 		}
 
@@ -220,7 +220,7 @@ SQL;
 
 	public function replace( string $key, int $flags, int $exptime, string|int $value ): bool {
 		$current = $this->get( [ $key ] );
-		if ( count( $current ) === 0 ) {
+		if ( [] === $current ) {
 			return false;
 		}
 
@@ -259,7 +259,7 @@ SQL;
 
 	public function touch( string $key, int $exptime ): bool {
 		$current = $this->get( [ $key ] );
-		if ( count( $current ) === 0 ) {
+		if ( [] === $current ) {
 			return false;
 		}
 

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -30,6 +30,7 @@ class Memcached_Storage {
 		$sql = 'SELECT name FROM sqlite_master WHERE type="table" AND name="storage"';
 		verbose( "SQLite: $sql" );
 		$table_check = self::$db->querySingle( $sql );
+		
 		if ( $table_check === null ) {
 			$sql = <<<SQL
 				CREATE TABLE IF NOT EXISTS 'storage' (

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -62,6 +62,7 @@ SQL;
 		$query = self::$db->prepare( 'DELETE FROM storage WHERE "key" = :key' );
 		$query->bindValue( ':key', $key, SQLITE3_TEXT );
 		verbose( "SQLite: {$query->getSQL( true )}" );
+		
 		return (bool) $query->execute();
 	}
 
@@ -83,8 +84,8 @@ SQL;
 		$query->bindValue( ':cas', 1, SQLITE3_INTEGER );
 		$query->bindValue( ':value', $value, SQLITE3_BLOB );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		return (bool) $query->execute();
 
+		return (bool) $query->execute();
 	}
 
 	public function append( string $key, int $flags, int $exptime, string|int $value ): bool {
@@ -213,8 +214,8 @@ SQL;
 		$query->bindValue( ':cas', 1, SQLITE3_INTEGER );
 		$query->bindValue( ':value', $value, SQLITE3_BLOB );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		return (bool) $query->execute();
 
+		return (bool) $query->execute();
 	}
 
 	public function stat_curr_items() {

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -138,7 +138,7 @@ SQL;
 		return self::$db->exec( $sql );
 	}
 
-	public function get( array $keys ): mixed {
+	public function get( array $keys ): array {
 		$sql = 'SELECT * FROM storage WHERE "key" IN ( ';
 		foreach ( $keys as $i => $k ) {
 			$sql .= ":key{$i}, ";

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -115,14 +115,9 @@ SQL;
 		verbose( "SQLite: {$query->getSQL( true )}" );
 		$result = $query->execute();
 
-		if (
-			$result !== false
-			&& self::$db->changes() === 1
-		) {
-			return true;
-		}
-
-		return false;
+		return ( $result !== false
+				&& self::$db->changes() === 1
+		);
 	}
 
 	public function decr( string $key, int $value): mixed {
@@ -191,11 +186,7 @@ SQL;
 			$new_value
 		);
 
-		if ( $results === true ) {
-			return $new_value;
-		}
-
-		return false;
+		return ( $results === true ) ? $new_value : false;
 	}
 
 	public function prepend( string $key, int $flags, int $exptime, string|int $value ): bool {

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -62,7 +62,7 @@ SQL;
 		$query = self::$db->prepare( 'DELETE FROM storage WHERE "key" = :key' );
 		$query->bindValue( ':key', $key, SQLITE3_TEXT );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		
+
 		return (bool) $query->execute();
 	}
 
@@ -167,11 +167,7 @@ SQL;
 
 	public function incr( string $key, int $value): mixed {
 		$results = $this->get( [ $key ] );
-		if ( [] === $results ) {
-			return false;
-		}
-
-		if ( !ctype_digit( $results[0]['value'] ) ) {
+		if ( [] === $results || !ctype_digit( $results[0]['value'] )) {
 			return false;
 		}
 

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -113,9 +113,8 @@ SQL;
 		$query->bindValue( ':cas', $cas, SQLITE3_INTEGER );
 		$query->bindValue( ':value', $value, SQLITE3_BLOB );
 		verbose( "SQLite: {$query->getSQL( true )}" );
-		$result = $query->execute();
 
-		return ( $result !== false && self::$db->changes() === 1 );
+		return ( $query->execute() !== false && self::$db->changes() === 1 );
 	}
 
 	public function decr( string $key, int $value): mixed {

--- a/lib/storage/sqlite.php
+++ b/lib/storage/sqlite.php
@@ -183,7 +183,7 @@ SQL;
 			$new_value
 		);
 
-		return ( $results === true ) ? $new_value : false;
+		return $results ? $new_value : false;
 	}
 
 	public function prepend( string $key, int $flags, int $exptime, string|int $value ): bool {


### PR DESCRIPTION
`$this->set()` always return bool

`[] === $results` is 3 x faster than `count( $results ) === 0`, and fix phpstan error

The methods that return bool,   `(bool) SQLite3Result|false`
Used `(bool) $result` because is more semantic than  `($result)`.

Changed type hint return in `get()`, always is array.