### PR TITLE
Use caret version range for phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"workerman/workerman": "^4.1"
 	},
 	"require-dev": {
-		"phpstan/phpstan": "1.8.0",
+		"phpstan/phpstan": "^1.7",
 		"pestphp/pest": "^1.21"
 	},
 	"suggest": {


### PR DESCRIPTION
So, we use the latest version without BC.
Now will be v1.9.11

But don't force it, so if another lib need another version don't conflict.